### PR TITLE
Rosinha alteração publicações

### DIFF
--- a/Press-Release/2023.06.02.spa.rst
+++ b/Press-Release/2023.06.02.spa.rst
@@ -57,7 +57,7 @@ A partir de este anuncio, el portal atiende a los siguientes elementos listados 
 
 ====
 
-.. centered:: Nuvem VMware
+.. centered:: Nube VMware
 
 ====
 

--- a/Press-Release/2023.06.09.spa.rst
+++ b/Press-Release/2023.06.09.spa.rst
@@ -55,7 +55,7 @@ En esta comunicación Ustore anuncia a su público interno y externo, los lanzam
 
 ====
 
-.. centered:: Nuvem Oracle
+.. centered:: Nube Oracle
 
 ====
 
@@ -94,7 +94,7 @@ En esta comunicación Ustore anuncia a su público interno y externo, los lanzam
 
 ====
 
-.. centered:: Nuvem Azure
+.. centered:: Nube Azure
 
 ====
 
@@ -102,10 +102,10 @@ En esta comunicación Ustore anuncia a su público interno y externo, los lanzam
 
 +----------------------------+---------------------------------------------------------------------------------------+
 |Feature                     |Tratamiento de errores en la eliminación de snapshots con comportamiento similar       |
-|                            |similar ucloud/nube                                                                    |
+|                            |ucloud/nube                                                                            |
 +============================+=======================================================================================+
 |Objetivo                    |Mejorar el comportamiento de snapshot para esta nube y la correcta presentación al     |
-|                            |al usuario.                                                                            |
+|                            |usuario.                                                                               |
 +----------------------------+---------------------------------------------------------------------------------------+
 |Nuevo funcionamiento del    |Al eliminar el snapshot, en caso de fallo el error se presenta al usuario en la        |
 |portal                      |pestaña de tareas.                                                                     |

--- a/Press-Release/2023.06.16.spa.rst
+++ b/Press-Release/2023.06.16.spa.rst
@@ -16,10 +16,10 @@
 2023.06.16
 ==========
 
-Nota de Prensa
+Nota de prensa
 --------------
 
-Año 2023 - Periodo del 12 al 16 de Junio
+Año 2023 - Periodo: del 12 al 16 de Junio
 
 ====
 

--- a/Press-Release/2023.06.23.eng.rst
+++ b/Press-Release/2023.06.23.eng.rst
@@ -6,12 +6,11 @@
 ----
 
 
-.. centered:: Português_      -     Español_     -     English  
+.. centered:: Português_      -     Español     -     English  
 
 
 .. _Português: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.html
 
-.. _Español: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.spa.html
 
 
 ====

--- a/Press-Release/2023.06.23.rst
+++ b/Press-Release/2023.06.23.rst
@@ -11,7 +11,7 @@
 
 .. _Español: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.spa.html
 
-.. _English: 
+.. _English: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.eng.html
 
 ====
 

--- a/Press-Release/2023.06.23.rst
+++ b/Press-Release/2023.06.23.rst
@@ -6,12 +6,12 @@
 ----
 
 
-.. centered:: Português      -     Español_     -     English_    
+.. centered:: Português      -     Español_     -     English    
 
 
 .. _Español: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.spa.html
 
-.. _English: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.eng.html
+
 
 ====
 

--- a/Press-Release/2023.06.23.spa.rst
+++ b/Press-Release/2023.06.23.spa.rst
@@ -6,12 +6,13 @@
 ----
 
 
-.. centered:: Português_      -     Español     -     English_    
+.. centered:: Português_      -     Español     -     English 
 
 
 .. _Português: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.html
 
-.. _English: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.eng.html
+
+
 
 ====
 

--- a/Press-Release/2023.06.23.spa.rst
+++ b/Press-Release/2023.06.23.spa.rst
@@ -11,7 +11,7 @@
 
 .. _Português: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.html
 
-.. _English:
+.. _English: https://ustore-software-e-servicos-ltda-manuais.readthedocs-hosted.com/pt/latest/Press-Release/2023.06.23.eng.html
 
 ====
 


### PR DESCRIPTION
nota de prensa:
correção no termo "nube".
press release:
exclusão "hyperlink" versão english.